### PR TITLE
Migrate to non-class implementation

### DIFF
--- a/src/extend.ts
+++ b/src/extend.ts
@@ -14,8 +14,6 @@ import type {
 import { unsafeCast } from './util/cast';
 import { toIterable } from './util/iterable';
 
-const isStringKey = (key: string) => Number.isNaN(parseInt(key, 10));
-
 const KIND = Symbol('ExtendedEnum');
 
 // eslint-disable-next-line no-underscore-dangle
@@ -50,6 +48,8 @@ const extend = <
   V extends Primitive,
 >(enumObj: E): ExtendedEnumStatic<E, V> => {
   const instances = new Map<V, ExtendedEnum<V>>();
+
+  const isStringKey = (key: string) => Number.isNaN(parseInt(key, 10));
 
   const keys = (): Iterable<Keys<E>> => Object.getOwnPropertyNames(enumObj).filter(isStringKey);
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -10,7 +10,7 @@ type ExtendedEnumEqualsMatcher<V extends Primitive> = {
   (value: ExtendedEnum<V>): boolean;
 };
 
-export type ExtendedEnumIs<V extends Primitive> = ExtendedEnumEqualsMatcher<V> & {
+type ExtendedEnumIs<V extends Primitive> = ExtendedEnumEqualsMatcher<V> & {
   readonly not: ExtendedEnumEqualsMatcher<V>;
 };
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -15,6 +15,12 @@ export type ExtendedEnumIs<V extends Primitive> = ExtendedEnumEqualsMatcher<V> &
 };
 
 export interface ExtendedEnum<V extends Primitive> {
+  /**
+   * This is a special attribute which is used to identify
+   * whether the object is an instance of extended enum.
+   */
+  readonly __kind: Symbol;
+
   readonly is: ExtendedEnumIs<V>;
 
   valueOf(): Primitive;


### PR DESCRIPTION
Use functional implementation instead of class implementation.
FP way is more easier when dealing with static members.