### PR TITLE
refactor(extend): switch to prototype implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Further extending default extended enumeration class is also possible. You may a
 class Pets extends extend<typeof _Animal, _Animal>(_Animal) {
 
   get walks(): boolean {
-    return this.is.not(Pets.Bird);
+    return this.isNot(Pets.Bird);
   }
 
 }

--- a/src/extend.spec.ts
+++ b/src/extend.spec.ts
@@ -237,24 +237,6 @@ describe('is', () => {
   });
 });
 
-describe('is.not', () => {
-  it('should work with primitives', () => {
-    expect(Fruit.of(FruitP.Apple).is.not('apple')).toBe(false);
-    expect(Fruit.of(FruitP.Apple).is.not('Apple')).toBe(true);
-    expect(Fruit.of(FruitP.Apple).is.not('pear')).toBe(true);
-    expect(Animal.of(AnimalP.Fox).is.not(3)).toBe(false);
-    expect(Animal.of(AnimalP.Fox).is.not('Fox')).toBe(true);
-    expect(Animal.of(AnimalP.Fox).is.not('fox')).toBe(true);
-    expect(Animal.of(AnimalP.Fox).is.not(AnimalP.Fox)).toBe(false);
-    expect(Animal.of(AnimalP.Fox).is.not(AnimalP.Dog)).toBe(true);
-  });
-
-  it('should work with instances', () => {
-    expect(Os.of(OsP.Android).is.not(Os.of(OsP.Android))).toBe(false);
-    expect(Os.of(OsP.Android).is.not(Os.of(OsP.iOS))).toBe(true);
-  });
-});
-
 describe('isNot', () => {
   it('should work with primitives', () => {
     expect(Fruit.of(FruitP.Apple).isNot('apple')).toBe(false);
@@ -331,12 +313,12 @@ describe('key accessors', () => {
     expect(Os.iOS.valueOf()).toBe('iOS');
 
     expect(Fruit.Apple.is(Fruit.Apple)).toBe(true);
-    expect(Fruit.Apple.is.not(Fruit.Pear)).toBe(true);
+    expect(Fruit.Apple.isNot(Fruit.Pear)).toBe(true);
     expect(Animal.Cat.is(AnimalP.Cat)).toBe(true);
     expect(Animal.Cat.is(0)).toBe(true);
     expect(Animal.Cat.is(Animal.of(AnimalP.Cat))).toBe(true);
     expect(Animal.Cat.is(Animal.Dog)).toBe(false);
-    expect(Animal.Cat.is.not(Animal.Fox)).toBe(true);
+    expect(Animal.Cat.isNot(Animal.Fox)).toBe(true);
   });
 
   it('returns the same instance with using "of"', () => {

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -8,7 +8,6 @@ import match from './match';
 import type {
   Enum,
   ExtendedEnum,
-  ExtendedEnumConstructor,
   ExtendedEnumMapping,
   ExtendedEnumStatic,
   Keys,
@@ -24,47 +23,46 @@ import {
   toEntry,
 } from './util/map';
 
+/**
+ * @remarks
+ *
+ * A unique symbol used internally,
+ * to verify whether an object is an instance of extended enum.
+ */
 const KIND = Symbol('ExtendedEnum');
 
 const isInstance = <
   E extends Enum,
   V extends Primitive,
-  // eslint-disable-next-line no-underscore-dangle
->(value: any): value is ExtendedEnum<E, V> => value.__kind === KIND;
-
-const instance = <
-  E extends Enum,
-  V extends Primitive,
-  K extends Keys<E>,
->(key: K, value: V): ExtendedEnum<E, V> => {
-  const eq = (other: V | Primitive | ExtendedEnum<E, V>): boolean => (
-    isInstance<E, V>(other) ? other.is(value) : other === value
+  >(value: any): value is ExtendedEnum<E, V> => (
+    // eslint-disable-next-line no-underscore-dangle
+    typeof value === 'object' && value.__kind === KIND
   );
 
-  const neq = (other: V | Primitive | ExtendedEnum<E, V>): boolean => !eq(other);
+interface Instance<
+  E extends Enum,
+  V extends Primitive,
+> {
+  key: Keys<E>;
+  value: V;
+}
 
-  const is = Object.assign(eq, { not: neq });
-  const isNot = is.not;
-
-  const keyOf = (): K => key;
-  const valueOf = (): V => value;
-
-  const toString = (): string => valueOf().toString();
-
-  const toJSON = valueOf;
-
-  return {
-    __kind: KIND,
-    __brand: key,
-    is,
-    isNot,
-    match,
-    keyOf,
-    valueOf,
-    toString,
-    toJSON,
-  };
-};
+/**
+ * @remarks
+ *
+ * The actual constructor of the extended enum instance.
+ */
+function instance<
+  E extends Enum,
+  V extends Primitive,
+>(
+  this: Instance<E, V>,
+  key: Keys<E>,
+  value: V,
+) {
+  this.key = key;
+  this.value = value;
+}
 
 const extend = <
   E extends Enum,
@@ -74,78 +72,148 @@ const extend = <
 
   const keys = (): Iterable<Keys<E>> => Object.getOwnPropertyNames(enumObj).filter(isStringKey);
 
-  // NOTE: this should be the only place where unsafe type link between E and V is applied
+  /**
+   * @remarks
+   *
+   * This should be the only place where unsafe type link between E and V is applied.
+   */
   const valueOf = (key: Keys<E>): V => unsafeCast<E[Keys<E>], V>(enumObj[key]);
 
   const rawValues = (): Iterable<V> => pipe(
     keys(),
-    map(valueOf),
+    map((key) => valueOf(key)),
     toIterable,
   );
 
-  // NOTE: cast from non-branded mapping to branded mapping
-  const instances = cast<Record<Keys<E>, ExtendedEnum<E, V>>, ExtendedEnumMapping<E, V>>(
-    pipe(
-      keys(),
-      map(toEntry(<K extends Keys<E>>(key: K) => instance<E, V, K>(key, valueOf(key)))),
-      fromEntries,
-    ),
-  );
+  const instances = new Map<Keys<E>, ExtendedEnum<E, V>>();
+  function memoizedInstance<K extends Keys<E>>(
+    this: ExtendedEnumStatic<E, V>,
+    key: K,
+  ): ExtendedEnumMapping<E, V>[K] {
+    if (instances.has(key)) { return cast(instances.get(key)!); }
 
-  const reverseMap = (value: V): Keys<E> => {
-    const found = find((key) => instances[key].is(value), keys());
+    /**
+     * @remarks
+     *
+     * We are **not** invoking the actual constructor of `this` using `new` keyword,
+     * but only setting the **prototype**.
+     * This avoids invoking the `FalseConstructor`, which throws an error.
+     *
+     * `Object.create` does this job.
+     */
+    const obj = Object.create(this.prototype);
+    instance.call(obj, key, valueOf(key));
+    instances.set(key, obj);
+
+    return obj;
+  }
+
+  function reverseMap(
+    this: ExtendedEnumStatic<E, V>,
+    value: V,
+  ): Keys<E> {
+    const found = find((key) => memoizedInstance.call(this, key).is(value), keys());
 
     if (!found) {
       throw new Error(`invalid value for reverse mapping, got: ${value}`);
     }
 
     return found;
-  };
+  }
 
-  const keyOf = (value: V | ExtendedEnum<E, V>): Keys<E> => reverseMap(
-    isInstance<E, V>(value) ? value.valueOf() : value,
+  function of(
+    this: ExtendedEnumStatic<E, V>,
+    value: V,
+  ): ExtendedEnum<E, V> {
+    return memoizedInstance.call(this, reverseMap.call(this, value));
+  }
+
+  function keyOf(
+    this: ExtendedEnumStatic<E, V>,
+    value: V | ExtendedEnum<E, V>,
+  ): Keys<E> {
+    return reverseMap.call(
+      this,
+      isInstance<E, V>(value) ? value.valueOf() : value,
+    );
+  }
+
+  function values(
+    this: ExtendedEnumStatic<E, V>,
+  ): Iterable<ExtendedEnum<E, V>> {
+    return pipe(
+      rawValues(),
+      map((rawValue) => this.of(rawValue)),
+      toIterable,
+    );
+  }
+
+  function entries(
+    this: ExtendedEnumStatic<E, V>,
+  ): Iterable<[Keys<E>, ExtendedEnum<E, V>]> {
+    return zip(keys(), this.values());
+  }
+
+  function from(
+    this: ExtendedEnumStatic<E, V>,
+    value: string | number | undefined,
+    fallback?: V,
+  ): ExtendedEnum<E, V> | undefined {
+    const wrapFallback = () => {
+      if (fallback === undefined) return fallback;
+      return this.of(fallback);
+    };
+
+    if (value === undefined) return wrapFallback();
+    return find((v) => v.is(value), this.values()) ?? wrapFallback();
+  }
+
+  function valuesIter(
+    this: ExtendedEnumStatic<E, V>,
+  ): Iterator<ExtendedEnum<E, V>> {
+    return this.values()[Symbol.iterator]();
+  }
+
+  const instanceDescriptors = pipe(
+    keys(),
+    map(toEntry((key) => ({
+      get(
+        this: ExtendedEnumStatic<E, V>,
+      ) { return memoizedInstance.call(this, key); },
+    }))),
+    fromEntries,
   );
 
-  const of = (value: V): ExtendedEnum<E, V> => instances[reverseMap(value)];
-
-  const values = (): Iterable<ExtendedEnum<E, V>> => pipe(
-    rawValues(),
-    map(of),
-    toIterable,
-  );
-
-  const entries = (): Iterable<[Keys<E>, ExtendedEnum<E, V>]> => zip(keys(), values());
-
-  const from = (
-    (value: string | number | undefined, fallback?: V): ExtendedEnum<E, V> | undefined => {
-      const wrapFallback = () => {
-        if (fallback === undefined) return fallback;
-        return of(fallback);
-      };
-
-      if (value === undefined) return wrapFallback();
-      return find((v) => v.is(value), values()) ?? wrapFallback();
-    }
-  ) as ExtendedEnumStatic<E, V>['from'];
-
-  return {
-    ...instances,
-
-    of,
-    from,
-    keys,
-    values,
-    rawValues,
-    entries,
-    keyOf,
-    [Symbol.iterator]: values()[Symbol.iterator],
-  };
+  return Object.defineProperties(
+    {
+      of,
+      from,
+      keys,
+      values,
+      rawValues,
+      entries,
+      keyOf,
+      [Symbol.iterator]: valuesIter,
+    },
+    instanceDescriptors,
+  ) as ExtendedEnumStatic<E, V>;
 };
 
 const extendWithFalseConstructor = <
   E extends Enum,
   V extends Primitive,
->(enumObj: E): ExtendedEnumStatic<E, V> & ExtendedEnumConstructor<E, V> => {
+>(enumObj: E): ExtendedEnumStatic<E, V> => {
+  /**
+   * @remarks
+   *
+   * The false constructor.
+   *
+   * When the inherited class invokes `super()` in its constructor,
+   * that will land to this false constructor.
+   *
+   * This indicates that instances of extended enum cannot be created manually,
+   * but it should be accessed by `of` or its key accessors.
+   */
   function FalseConstructor(): ExtendedEnum<E, V> {
     throw new Error(`The constructor of ExtendedEnum is not actually implemented.
 
@@ -155,7 +223,51 @@ so that further extending the class is allowed.
 If the constructor is actually invoked, it will throw an error.`);
   }
 
-  return unsafeCast(Object.assign(FalseConstructor, extend(enumObj)));
+  Object.defineProperty(FalseConstructor.prototype, '__kind', { get() { return KIND; } });
+
+  FalseConstructor.prototype.eq = function eq(other: V | Primitive): boolean {
+    return this.value === other;
+  };
+
+  FalseConstructor.prototype.is = function is(other: V | Primitive | ExtendedEnum<E, V>): boolean {
+    return isInstance<E, V>(other) ? other.is(this.value) : this.eq(other);
+  };
+
+  FalseConstructor.prototype.isNot = function isNot(
+    other: V | Primitive | ExtendedEnum<E, V>,
+  ): boolean {
+    return !this.is(other);
+  };
+
+  FalseConstructor.prototype.keyOf = function keyOf(): Keys<E> {
+    return this.key;
+  };
+
+  FalseConstructor.prototype.valueOf = function valueOf(): V {
+    return this.value;
+  };
+
+  FalseConstructor.prototype.toString = function toString(): string {
+    return this.valueOf().toString();
+  };
+
+  FalseConstructor.prototype.toJSON = function toJSON(): Primitive {
+    return this.valueOf();
+  };
+
+  FalseConstructor.prototype.match = match;
+
+  /**
+   * @remarks
+   *
+   * We are defining static methods here.
+   */
+  Object.defineProperties(FalseConstructor, Object.getOwnPropertyDescriptors(extend(enumObj)));
+
+  Object.seal(FalseConstructor);
+  Object.seal(FalseConstructor.prototype);
+
+  return unsafeCast(FalseConstructor);
 };
 
 export default extendWithFalseConstructor;

--- a/src/extend.ts-spec.ts
+++ b/src/extend.ts-spec.ts
@@ -20,12 +20,6 @@ checks(
   equal<ReturnType<typeof apple.is>, boolean>(),
 );
 
-/* is.not */
-checks(
-  extendTypeOf<typeof apple.is.not, Function>(),
-  equal<ReturnType<typeof apple.is.not>, boolean>(),
-);
-
 declare const fruit: ExtendedEnum<typeof FruitP, FruitP>;
 
 const keyOfFruit = Fruit.keyOf(fruit);


### PR DESCRIPTION
Partial fix of #54 
This re-implements existing feature with prototype inheritance, so that extending the class is possible.