### PR TITLE
Lower required typescript version in peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ yarn add extended-enum@latest
 
 ### Peer dependencies
 
-This project requires `typescript@4.6.0` or higher. Install peer dependencies via:
+This project requires `typescript@4.1.2` or higher. Install peer dependencies via:
 
 ```sh
 # NPM
-npm i -D typescript@^4.6.0
+npm i -D typescript@^4.1.2
 
 # Yarn
-yarn add -D typescript@^4.6.0
+yarn add -D typescript@^4.1.2
 ```
 
 ## How to use it?

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "@fxts/core": "^0.5.0"
   },
   "peerDependencies": {
-    "typescript": "^4.6.0"
+    "typescript": "^4.1.2"
   }
 }


### PR DESCRIPTION
Originally, it was intended to use TS 4.6 features while solving #54. But it was found out that it can be resolved without upgrading TS.