### PR TITLE
Support inheriting base ExtendedEnum

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,19 +215,25 @@ fruit.match([
 
 ### Inheriting extended enumerations
 
-> WIP (coming in v0.4.0)
-
-Further extending default extended enumeration class is also possible. You may add more querying methods (modifying internal state of the instance is not encouraged), or override existing core methods such as `is` or `from` to customize the default behavior.
+Further extending default extended enumeration class is also possible. You may add more methods, or override existing core methods such as `is` or `from` to customize the default behavior.
 
 ```typescript
-// you may add more querying methods to extend enumerations
-class EPets extends extend<typeof Animal, Animal>(Animal) {
+// define the extended interface
+interface IPet {
+  readonly walks: boolean
+}
+
+// you may add more methods to extend enumerations
+class EPets extends extend<typeof Animal, Animal, IPet>(Animal) {
 
   get walks(): boolean {
     return this.isNot(EPets.Bird);
   }
 
 }
+
+EPets.Cat.walks  // true
+EPets.Bird.walks // false
 ```
 
 ## API Documentation

--- a/src/extend-inheritance.spec.ts
+++ b/src/extend-inheritance.spec.ts
@@ -1,0 +1,204 @@
+/* eslint-disable max-classes-per-file */
+
+import {
+  pipe,
+  toArray,
+} from '@fxts/core';
+import extend from './extend';
+
+describe('define methods', () => {
+  it('should work with number enumerations', () => {
+    enum Fruit { Apple, Orange }
+
+    interface IFruit {
+      readonly price: number;
+      likes(): boolean;
+    }
+
+    class EFruit extends extend<typeof Fruit, Fruit, IFruit>(Fruit) {
+      get price(): number {
+        return this.match({
+          [Fruit.Apple]: 1,
+          [Fruit.Orange]: 1.5,
+        }, 0);
+      }
+
+      likes(): boolean {
+        return this.is(Fruit.Apple);
+      }
+
+      static get displayName(): string {
+        return 'Fruit';
+      }
+    }
+
+    expect(EFruit.displayName).toBe('Fruit');
+    expect(EFruit.Apple.price).toBe(1);
+    expect(EFruit.Orange.price).toBe(1.5);
+    expect(EFruit.Apple.likes()).toBe(true);
+    expect(EFruit.Orange.likes()).toBe(false);
+  });
+
+  it('should work with mixed enumerations', () => {
+    enum Animal {
+      Cat,
+      Dog = 'dog',
+      Elephant = 'elephant',
+    }
+
+    interface IAnimal {
+      barks(): boolean
+      serialize(): string
+    }
+
+    class EAnimal extends extend<typeof Animal, Animal, IAnimal>(Animal) {
+      barks(): boolean {
+        return this.is(Animal.Dog);
+      }
+
+      serialize(): string {
+        return ['Animal', this.toString()].join(':');
+      }
+    }
+
+    expect(EAnimal.Cat.barks()).toBe(false);
+    expect(EAnimal.Dog.barks()).toBe(true);
+    expect(EAnimal.Cat.serialize()).toBe('Animal:0');
+    expect(EAnimal.Elephant.serialize()).toBe('Animal:elephant');
+  });
+});
+
+describe('extend', () => {
+  it('should be working with instanceof operator', () => {
+    enum Fruit { Apple, Orange }
+    const EFruitBase = extend<typeof Fruit, Fruit>(Fruit);
+    class EFruit extends EFruitBase {
+      get name() { return this.keyOf(); }
+    }
+
+    enum Animal { Cat, Dog }
+
+    class EAnimal extends extend<typeof Animal, Animal>(Animal) {
+      barks(): boolean {
+        return this.is(Animal.Dog);
+      }
+    }
+
+    expect(EFruit.Apple instanceof EFruit).toBe(true);
+    expect(Object.prototype.isPrototypeOf.call(EFruit, EFruitBase));
+    expect(EAnimal.Cat instanceof EAnimal).toBe(true);
+    expect(EAnimal.Cat instanceof EFruit).toBe(false);
+  });
+});
+
+describe('Overriding "eq"', () => {
+  enum Level { Low = 'low', Medium = 'medium', High = 'high' }
+  class ELevel extends extend<typeof Level, Level>(Level) {
+    eq(other: string): boolean {
+      return this.valueOf().charAt(0) === other.toString().toLowerCase().charAt(0);
+    }
+  }
+
+  it('also updates behavior of "is"', () => {
+    expect(ELevel.Low.is(ELevel.Low)).toBe(true);
+    expect(ELevel.Low.is(ELevel.Medium)).toBe(false);
+    expect(ELevel.Low.is('LOW')).toBe(true);
+    expect(ELevel.Low.is('MEDIUM')).toBe(false);
+    expect(ELevel.Medium.is('medium')).toBe(true);
+    expect(ELevel.Medium.is('M')).toBe(true);
+    expect(ELevel.Medium.is('high')).toBe(false);
+    expect(ELevel.High.is('VERY_HIGH')).toBe(false);
+    expect(ELevel.High.is('h')).toBe(true);
+  });
+
+  it('also updates behavior of "isNot"', () => {
+    expect(ELevel.Low.isNot(ELevel.Low)).toBe(false);
+    expect(ELevel.Low.isNot(ELevel.Medium)).toBe(true);
+    expect(ELevel.Low.isNot('LOW')).toBe(false);
+    expect(ELevel.Low.isNot('MEDIUM')).toBe(true);
+    expect(ELevel.Medium.isNot('medium')).toBe(false);
+    expect(ELevel.Medium.isNot('M')).toBe(false);
+    expect(ELevel.Medium.isNot('high')).toBe(true);
+    expect(ELevel.High.isNot('VERY_HIGH')).toBe(true);
+    expect(ELevel.High.isNot('h')).toBe(false);
+  });
+
+  it('also updates behavior of "from"', () => {
+    expect(ELevel.from('l')).toBe(ELevel.Low);
+    expect(ELevel.from('m')).toBe(ELevel.Medium);
+    expect(ELevel.from('h')).toBe(ELevel.High);
+    expect(() => ELevel.from('_')).not.toThrow();
+    expect(ELevel.from('_')).toBe(undefined);
+    expect(ELevel.from('_', Level.Low)).toBe(ELevel.Low);
+  });
+
+  it('also updates behavior of "match"', () => {
+    expect(ELevel.Low.match({
+      l: 10,
+      m: 20,
+      h: 30,
+    })).toBe(10);
+
+    expect(ELevel.High.match([
+      ['LOW', 'easy'],
+      ['MEDIUM', 'average'],
+      ['HIGH', 'difficult'],
+    ])).toBe('difficult');
+
+    expect(ELevel.Low.match({
+      a: 'a',
+      b: 'b',
+      c: 'c',
+    }, 'fallback')).toBe('fallback');
+  });
+});
+
+describe('Overriding "values"', () => {
+  enum Animal { Cat, Dog, Fox, $Unknown }
+  class EAnimal extends extend<typeof Animal, Animal>(Animal) {
+    static values = function* overrided() {
+      yield EAnimal.Cat;
+      yield EAnimal.Dog;
+      yield EAnimal.Fox;
+    };
+  }
+
+  it('does updates the overrided field', () => {
+    expect(pipe(
+      EAnimal.values(),
+      toArray,
+    )).toEqual([
+      EAnimal.Cat,
+      EAnimal.Dog,
+      EAnimal.Fox,
+    ]);
+  });
+
+  it('also updates behavior of "entries"', () => {
+    expect(pipe(
+      EAnimal.entries(),
+      toArray,
+    )).toEqual([
+      ['Cat', EAnimal.Cat],
+      ['Dog', EAnimal.Dog],
+      ['Fox', EAnimal.Fox],
+    ]);
+  });
+
+  it('also updates behavior of "[Symbol.iterator]"()', () => {
+    expect(pipe(
+      EAnimal,
+      toArray,
+    )).toEqual([
+      EAnimal.Cat,
+      EAnimal.Dog,
+      EAnimal.Fox,
+    ]);
+  });
+
+  it('also updates behavior of "from"', () => {
+    expect(EAnimal.from(0)).toBe(EAnimal.Cat);
+    expect(EAnimal.from(3)).not.toBe(EAnimal.$Unknown);
+    expect(EAnimal.from(3)).toBe(undefined);
+  });
+});

--- a/src/extend-inheritance.ts-spec.ts
+++ b/src/extend-inheritance.ts-spec.ts
@@ -1,0 +1,82 @@
+import {
+  filter,
+  map,
+  pipe,
+  toArray,
+} from '@fxts/core';
+import extend from './extend';
+import {
+  checks,
+  equal,
+  extend as extendTypeOf,
+} from './test/typecheck';
+
+enum Fruit { Apple, Orange, Strawberry }
+
+interface IFruit {
+  readonly name: string
+  likes(): boolean
+}
+
+class EFruit extends extend<typeof Fruit, Fruit, IFruit>(Fruit) {
+  get name(): string {
+    return ['Fruit', this.toString()].join(':');
+  }
+
+  likes(): boolean {
+    return this.is(EFruit.Apple);
+  }
+}
+
+declare const fruit: EFruit;
+
+checks(
+  extendTypeOf<Fruit.Apple, Fruit>(),
+  extendTypeOf<typeof EFruit.Orange, EFruit>(),
+);
+
+(function definedPropertyIsVisible(f: EFruit) {
+  type T1 = typeof f.name;
+  type T2 = typeof EFruit.Apple.name;
+
+  const orange = EFruit.of(Fruit.Orange);
+  type T3 = typeof orange.name;
+
+  const parsed = EFruit.from('foo', Fruit.Apple);
+  type T4 = typeof parsed.name;
+
+  const names = pipe(EFruit.values(), map((_) => _.name), toArray);
+  type T5 = typeof names;
+
+  checks(
+    equal<T1, string>(),
+    equal<T2, string>(),
+    equal<T3, string>(),
+    equal<T4, string>(),
+    equal<T5, string[]>(),
+  );
+}(fruit));
+
+(function definedMethodIsVisible(f: EFruit) {
+  type T1 = typeof f.likes;
+  type T2 = typeof EFruit.Apple.likes;
+
+  const orange = EFruit.of(Fruit.Orange);
+  type T3 = typeof orange.likes;
+
+  const parsed = EFruit.from('foo', Fruit.Apple);
+  type T4 = typeof parsed.likes;
+
+  const liked = pipe(EFruit.values(), filter((_) => _.likes()), toArray);
+  type T5 = typeof liked;
+
+  type LikedFn = () => boolean;
+
+  checks(
+    equal<T1, LikedFn>(),
+    equal<T2, LikedFn>(),
+    equal<T3, LikedFn>(),
+    equal<T4, LikedFn>(),
+    extendTypeOf<T5, EFruit[]>(),
+  );
+}(fruit));

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -67,7 +67,8 @@ function instance<
 const extend = <
   E extends Enum,
   V extends Primitive,
->(enumObj: E): ExtendedEnumStatic<E, V> => {
+  M,
+>(enumObj: E): ExtendedEnumStatic<E, V, M> => {
   const isStringKey = (key: string) => Number.isNaN(parseInt(key, 10));
 
   const keys = (): Iterable<Keys<E>> => Object.getOwnPropertyNames(enumObj).filter(isStringKey);
@@ -87,9 +88,9 @@ const extend = <
 
   const instances = new Map<Keys<E>, ExtendedEnum<E, V>>();
   function memoizedInstance<K extends Keys<E>>(
-    this: ExtendedEnumStatic<E, V>,
+    this: ExtendedEnumStatic<E, V, M>,
     key: K,
-  ): ExtendedEnumMapping<E, V>[K] {
+  ): ExtendedEnumMapping<E, V, M>[K] {
     if (instances.has(key)) { return cast(instances.get(key)!); }
 
     /**
@@ -109,7 +110,7 @@ const extend = <
   }
 
   function reverseMap(
-    this: ExtendedEnumStatic<E, V>,
+    this: ExtendedEnumStatic<E, V, M>,
     value: V,
   ): Keys<E> {
     const found = find((key) => memoizedInstance.call(this, key).is(value), keys());
@@ -122,14 +123,14 @@ const extend = <
   }
 
   function of(
-    this: ExtendedEnumStatic<E, V>,
+    this: ExtendedEnumStatic<E, V, M>,
     value: V,
   ): ExtendedEnum<E, V> {
     return memoizedInstance.call(this, reverseMap.call(this, value));
   }
 
   function keyOf(
-    this: ExtendedEnumStatic<E, V>,
+    this: ExtendedEnumStatic<E, V, M>,
     value: V | ExtendedEnum<E, V>,
   ): Keys<E> {
     return reverseMap.call(
@@ -139,7 +140,7 @@ const extend = <
   }
 
   function values(
-    this: ExtendedEnumStatic<E, V>,
+    this: ExtendedEnumStatic<E, V, M>,
   ): Iterable<ExtendedEnum<E, V>> {
     return pipe(
       rawValues(),
@@ -149,13 +150,13 @@ const extend = <
   }
 
   function entries(
-    this: ExtendedEnumStatic<E, V>,
+    this: ExtendedEnumStatic<E, V, M>,
   ): Iterable<[Keys<E>, ExtendedEnum<E, V>]> {
     return zip(keys(), this.values());
   }
 
   function from(
-    this: ExtendedEnumStatic<E, V>,
+    this: ExtendedEnumStatic<E, V, M>,
     value: string | number | undefined,
     fallback?: V,
   ): ExtendedEnum<E, V> | undefined {
@@ -169,7 +170,7 @@ const extend = <
   }
 
   function valuesIter(
-    this: ExtendedEnumStatic<E, V>,
+    this: ExtendedEnumStatic<E, V, M>,
   ): Iterator<ExtendedEnum<E, V>> {
     return this.values()[Symbol.iterator]();
   }
@@ -178,7 +179,7 @@ const extend = <
     keys(),
     map(toEntry((key) => ({
       get(
-        this: ExtendedEnumStatic<E, V>,
+        this: ExtendedEnumStatic<E, V, M>,
       ) { return memoizedInstance.call(this, key); },
     }))),
     fromEntries,
@@ -196,13 +197,14 @@ const extend = <
       [Symbol.iterator]: valuesIter,
     },
     instanceDescriptors,
-  ) as ExtendedEnumStatic<E, V>;
+  ) as ExtendedEnumStatic<E, V, M>;
 };
 
 const extendWithFalseConstructor = <
   E extends Enum,
   V extends Primitive,
->(enumObj: E): ExtendedEnumStatic<E, V> => {
+  M = {},
+>(enumObj: E): ExtendedEnumStatic<E, V, M> => {
   /**
    * @remarks
    *

--- a/src/type.ts
+++ b/src/type.ts
@@ -146,11 +146,11 @@ type ExtendedEnumOfKey<E extends Enum, V extends Primitive, K extends Keys<E>> =
 
 export type ExtendedEnum<E extends Enum, V extends Primitive> = ExtendedEnumOfKey<E, V, Keys<E>>;
 
-export type ExtendedEnumMapping<E extends Enum, V extends Primitive> = {
-  [K in Keys<E>]: ExtendedEnumOfKey<E, V, K>;
+export type ExtendedEnumMapping<E extends Enum, V extends Primitive, M> = {
+  [K in Keys<E>]: ExtendedEnumOfKey<E, V, K> & M;
 };
 
-type ExtendedEnumStaticMethods<E extends Enum, V extends Primitive> = {
+type ExtendedEnumStaticMethods<E extends Enum, V extends Primitive, M> = {
   /**
    * `of` returns an instance of extended enumeration with given primitive.
    *
@@ -171,9 +171,9 @@ type ExtendedEnumStaticMethods<E extends Enum, V extends Primitive> = {
    * ```
    */
   of(
-    this: ExtendedEnumStatic<E, V>,
+    this: ExtendedEnumStatic<E, V, M>,
     value: V,
-  ): ExtendedEnum<E, V>;
+  ): ExtendedEnum<E, V> & M;
 
   /**
    * `from` returns an instance of extended enumeration with given value.
@@ -195,14 +195,14 @@ type ExtendedEnumStaticMethods<E extends Enum, V extends Primitive> = {
    * ```
    */
   from(
-    this: ExtendedEnumStatic<E, V>,
+    this: ExtendedEnumStatic<E, V, M>,
     value: string | number | undefined,
-  ): ExtendedEnum<E, V> | undefined;
+  ): ExtendedEnum<E, V> & M | undefined;
   from(
-    this: ExtendedEnumStatic<E, V>,
+    this: ExtendedEnumStatic<E, V, M>,
     value: string | number | undefined,
     fallback: V,
-  ): ExtendedEnum<E, V>;
+  ): ExtendedEnum<E, V> & M;
 
   /**
    * Returns an iterable of defined keys.
@@ -262,7 +262,7 @@ type ExtendedEnumStaticMethods<E extends Enum, V extends Primitive> = {
    * @see rawValues
    * @see entries
    */
-  values(this: ExtendedEnumStatic<E, V>): Iterable<ExtendedEnum<E, V>>;
+  values(this: ExtendedEnumStatic<E, V, M>): Iterable<ExtendedEnum<E, V> & M>;
 
   /**
    * Returns an iterable of tuple `[key, instance]`.
@@ -284,8 +284,8 @@ type ExtendedEnumStaticMethods<E extends Enum, V extends Primitive> = {
    * @see values
    */
   entries(
-    this: ExtendedEnumStatic<E, V>,
-  ): Iterable<[Keys<E>, ExtendedEnum<E, V>]>;
+    this: ExtendedEnumStatic<E, V, M>,
+  ): Iterable<[Keys<E>, ExtendedEnum<E, V> & M]>;
 
   /**
    * `keyOf` corresponds to the reverse mapping feature
@@ -318,10 +318,10 @@ type ExtendedEnumStaticMethods<E extends Enum, V extends Primitive> = {
   keyOf<K extends Keys<E>>(value: ExtendedEnumOfKey<E, V, K>): K;
 };
 
-export type ExtendedEnumStatic<E extends Enum, V extends Primitive> =
-  & Iterable<ExtendedEnum<E, V>>
-  & ExtendedEnumMapping<E, V>
-  & ExtendedEnumStaticMethods<E, V>
+export type ExtendedEnumStatic<E extends Enum, V extends Primitive, M = {}> =
+  & Iterable<ExtendedEnum<E, V> & M>
+  & ExtendedEnumMapping<E, V, M>
+  & ExtendedEnumStaticMethods<E, V, M>
   & {
     /**
      * @deprecated The constructor is not actually implemented.
@@ -331,5 +331,5 @@ export type ExtendedEnumStatic<E extends Enum, V extends Primitive> =
      *
      * If the constructor is actually invoked, it will throw an error.
      */
-    new (): ExtendedEnum<E, V>
+    new (): ExtendedEnum<E, V> & M
   };


### PR DESCRIPTION
Fixes #54 

- [x] Supports extending `extend`ed enums and defining methods
- [x] Supports type definition
- [x] Supports overriding core methods (`is`, `from`)